### PR TITLE
Fetch status from status.io

### DIFF
--- a/src/helper/statusioHelper.js
+++ b/src/helper/statusioHelper.js
@@ -1,0 +1,24 @@
+const getOverallStatusCodeOf = (statusJson) =>
+  statusJson.result.status_overall.status_code;
+
+export const getStatusOf = async (statusId) => {
+  const response = await fetch(`https://status.io/1.0/status/${statusId}`);
+  return response.json();
+};
+
+export const getStatusTickerDataOf = (rawStatusPair) => {
+  const { platform, status } = rawStatusPair;
+  if (!status) {
+    return {
+      platform,
+    };
+  }
+
+  const statusCode = getOverallStatusCodeOf(status);
+  return {
+    platform,
+    fetching: false,
+    minor: statusCode > 100 && statusCode < 500,
+    major: statusCode >= 500,
+  };
+};

--- a/src/store/statusioStore.js
+++ b/src/store/statusioStore.js
@@ -1,0 +1,42 @@
+import { readable, derived } from 'svelte/store';
+import { getStatusOf, getStatusTickerDataOf } from '../helper/statusioHelper';
+
+const generatePair = (platform, statusId) => ({
+  platform,
+  statusId,
+});
+
+const platformStatusIdpairs = [
+  generatePair('Docker Hub', '533c6539221ae15e3f000031'),
+  generatePair('GitLab', '5b36dc6502d06804c08349f7'),
+  generatePair("Let's Encrypt", '55957a99e800baa4470002da'),
+];
+
+const storeValueOf = (platform, status = null) => ({ platform, status });
+
+const createStatusioReadableStore = (platform, statusId) => {
+  const statusioReadableStore = readable(
+    storeValueOf(platform),
+    async (set) => {
+      const updateStatus = async () => {
+        const status = await getStatusOf(statusId);
+        set(storeValueOf(platform, status));
+      };
+
+      await updateStatus();
+      const interval = setInterval(updateStatus, 90_000);
+      return () => clearInterval(interval);
+    }
+  );
+
+  return statusioReadableStore;
+};
+
+export const statusioStores = platformStatusIdpairs.map((pair) =>
+  createStatusioReadableStore(pair.platform, pair.statusId)
+);
+export const statusioTickerStores = statusioStores.map((rawStatusStore) =>
+  derived(rawStatusStore, ($rawStatusPair) =>
+    getStatusTickerDataOf($rawStatusPair)
+  )
+);


### PR DESCRIPTION
Related issue: resolve #34

fetch & manage real-world status data w/ store

(platform, raw status) pair is managed w/ readable store
status ticker data is managed w/ derived store