### PR TITLE
Support dark mode

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -6,13 +6,15 @@ body {
 }
 
 body {
-  color: #333;
+  color: var(--font-color);
   margin: 0;
   box-sizing: border-box;
   font-family: 'Helvetica Neue', sans-serif;
 
   -ms-overflow-style: none;
   scrollbar-width: none;
+
+  background: var(--background-color);
 }
 
 body::-webkit-scrollbar {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,7 +31,7 @@
 
   @media (prefers-color-scheme: dark) {
     :root {
-      --font-color: #ffffff;
+      --font-color: #cccccc;
       --secondary-font-color: #737373;
       --background-color: #000000;
       --border-color: #ffffff;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,10 @@
 
     --font-weight-bold: 700;
     --font-weight-light: 300;
+
+    --font-color: #333333;
+    --background-color: #ffffff;
+    --border-color: #000000;
   }
 
   main {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,6 +29,15 @@
     padding-top: var(--header-height);
   }
 
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --font-color: #ffffff;
+      --secondary-font-color: #737373;
+      --background-color: #000000;
+      --border-color: #ffffff;
+    }
+  }
+
   @media (max-width: 759px) {
     :root {
       --header-height: 80px;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
     --font-weight-light: 300;
 
     --font-color: #333333;
+    --secondary-font-color: #c4c4c4;
     --background-color: #ffffff;
     --border-color: #000000;
   }

--- a/src/component/Modal.svelte
+++ b/src/component/Modal.svelte
@@ -55,16 +55,6 @@
     display: none;
   }
 
-  .header-ticker-cover {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-
-    height: calc(var(--header-height) + 40px);
-    background: var(--background-color);
-  }
-
   @media (min-width: 760px) {
     .container {
       width: 700px;
@@ -89,7 +79,6 @@
 
 <div data-testid="overlay" class="modal-overlay" class:closed={!show}>
   <div data-testid="container" class="container">
-    <div data-testid="header-ticker-cover" class="header-ticker-cover" />
     <div data-testid="cancel-button-container" class="cancel-button-container">
       <div data-testid="cancel-button" class="cancel-button" on:click={onClose}>
         CANCEL

--- a/src/component/Modal.svelte
+++ b/src/component/Modal.svelte
@@ -23,7 +23,8 @@
     left: 0;
     right: 0;
 
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--background-color);
+    opacity: 0.9;
 
     z-index: 139;
   }
@@ -61,7 +62,7 @@
     right: 0;
 
     height: calc(var(--header-height) + 40px);
-    background: #ffffff;
+    background: var(--background-color);
   }
 
   @media (min-width: 760px) {

--- a/src/component/SearchBar.svelte
+++ b/src/component/SearchBar.svelte
@@ -68,7 +68,7 @@
   }
 
   .search-bar::placeholder {
-    color: #c4c4c4;
+    color: var(--secondary-font-color);
     font-weight: var(--font-weight-light);
   }
 

--- a/src/component/SearchBar.svelte
+++ b/src/component/SearchBar.svelte
@@ -62,6 +62,9 @@
     padding: 0;
     width: 100%;
     flex: 1;
+
+    background: var(--background-color);
+    color: var(--font-color);
   }
 
   .search-bar::placeholder {

--- a/src/component/StatusTicker.svelte
+++ b/src/component/StatusTicker.svelte
@@ -42,8 +42,10 @@
     overflow: hidden;
 
     box-sizing: border-box;
-    border-top: 1px solid #000000;
-    border-bottom: 1px solid #000000;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+
+    background: var(--background-color);
   }
 
   .status-ticker-viewport-inner {

--- a/src/container/Header.svelte
+++ b/src/container/Header.svelte
@@ -25,7 +25,7 @@
     justify-content: space-between;
     text-align: center;
 
-    border-bottom: 1px solid #000000;
+    border-bottom: 1px solid var(--border-color);
   }
 
   .title {
@@ -42,7 +42,7 @@
   .settings {
     font-size: var(--font-size-regular);
     font-weight: var(--font-weight-light);
-    color: rgba(0, 0, 0, 0.3);
+    color: var(--secondary-font-color);
     margin: auto 0;
   }
 

--- a/src/container/Header.svelte
+++ b/src/container/Header.svelte
@@ -15,7 +15,6 @@
     left: 0;
     right: 0;
 
-    background: #ffffff;
     z-index: 99;
   }
 

--- a/test/component/Modal.test.js
+++ b/test/component/Modal.test.js
@@ -62,22 +62,6 @@ describe('Render Modal', () => {
       position: 'relative',
     });
   });
-
-  it('should cover header & ticker', () => {
-    const { getByTestId } = render(Modal);
-
-    const headerCover = getByTestId('header-ticker-cover');
-
-    expect(headerCover).toBeVisible();
-    expect(headerCover).toHaveStyle({
-      position: 'absolute',
-      top: '0',
-      left: '0',
-      right: '0',
-      height: 'calc(var(--header-height) + 40px)',
-      background: 'var(--background-color)',
-    });
-  });
 });
 
 describe('Render Cancel button', () => {

--- a/test/component/Modal.test.js
+++ b/test/component/Modal.test.js
@@ -17,13 +17,14 @@ describe('Render Modal overlay', () => {
     });
   });
 
-  it('should overlay have white background color w/ little transparency', () => {
+  it('should overlay have global background color w/ little transparency', () => {
     const { getByTestId } = render(Modal);
 
     const overlay = getByTestId('overlay');
 
     expect(overlay).toHaveStyle({
-      background: 'rgba(255, 255, 255, 0.9)',
+      background: 'var(--background-color)',
+      opacity: 0.9,
     });
   });
 
@@ -74,7 +75,7 @@ describe('Render Modal', () => {
       left: '0',
       right: '0',
       height: 'calc(var(--header-height) + 40px)',
-      background: '#FFFFFF',
+      background: 'var(--background-color)',
     });
   });
 });

--- a/test/component/SearchBar.test.js
+++ b/test/component/SearchBar.test.js
@@ -87,6 +87,17 @@ describe('Check Search Bar style', () => {
     });
   });
 
+  it('should render search bar with global background & font color', async () => {
+    const { getByTestId } = render(SearchBar);
+
+    const searchContainer = getByTestId('search-container');
+
+    expect(searchContainer).toHaveStyle({
+      color: 'var(--font-color)',
+      background: 'var(--background-color)',
+    });
+  });
+
   it('should render search bar component have default font setting as large & light', async () => {
     const { getByTestId } = render(SearchBar);
 

--- a/test/component/StatusTicker.test.js
+++ b/test/component/StatusTicker.test.js
@@ -37,6 +37,20 @@ describe('Render Viewport', () => {
     });
   });
 
+  it('should have background color as global variable', async () => {
+    const { getByTestId } = render(StatusTicker, {
+      props: {
+        statusTickerDatas: statusTickerMockDatas,
+      },
+    });
+
+    const statusTickerViewport = getByTestId('status-ticker-viewport');
+
+    expect(statusTickerViewport).toHaveStyle({
+      background: 'var(--background-color)',
+    });
+  });
+
   it('should sizing w/ border-box', async () => {
     const { getByTestId } = render(StatusTicker, {
       props: {
@@ -61,8 +75,8 @@ describe('Render Viewport', () => {
     const statusTickerViewport = getByTestId('status-ticker-viewport');
 
     expect(statusTickerViewport).toHaveStyle({
-      'border-top': '1px solid #000000',
-      'border-bottom': '1px solid #000000',
+      'border-top': '1px solid var(--border-color)',
+      'border-bottom': '1px solid var(--border-color)',
     });
   });
 

--- a/test/container/Header.test.js
+++ b/test/container/Header.test.js
@@ -2,16 +2,6 @@ import { fireEvent, render } from '@testing-library/svelte';
 import Header from '../../src/container/Header.svelte';
 
 describe('Render Header', () => {
-  it('should have white background', async () => {
-    const { getByTestId } = render(Header);
-
-    const header = getByTestId('header');
-
-    expect(header).toHaveStyle({
-      background: '#FFFFFF',
-    });
-  });
-
   it('should render search, title, setting', async () => {
     const { getByTestId } = render(Header);
 


### PR DESCRIPTION
## Related Issue
resolve #62 

## Description
Support dark mode on system preference (dark mode on OS level)
Use global variables for handling color change

+ modal will not cover header & ticker after this PR

<img width="1904" alt="Screen Shot 2021-01-21 at 3 03 10 PM" src="https://user-images.githubusercontent.com/18724352/105286731-3b504500-5bfa-11eb-8e00-1a8f5970b7f2.png">
<img width="1904" alt="Screen Shot 2021-01-21 at 3 07 00 PM" src="https://user-images.githubusercontent.com/18724352/105286816-5d49c780-5bfa-11eb-8d45-2cb2c05d1dfa.png">
