### PR TITLE
Set status color as global variable

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -40,6 +40,8 @@
       --secondary-font-color: #737373;
       --background-color: #000000;
       --border-color: #ffffff;
+
+      --fetching-color: rgba(255, 255, 255, 0.2);
     }
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,6 +20,11 @@
     --secondary-font-color: #c4c4c4;
     --background-color: #ffffff;
     --border-color: #000000;
+
+    --operational-color: rgba(39, 174, 96, 0.5);
+    --minor-outage-color: rgba(242, 153, 74, 0.5);
+    --major-outage-color: rgba(235, 87, 87, 0.5);
+    --fetching-color: rgba(0, 0, 0, 0.2);
   }
 
   main {

--- a/src/component/StatusTickerItem.svelte
+++ b/src/component/StatusTickerItem.svelte
@@ -43,19 +43,19 @@
   }
 
   .fetching {
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--fetching-color);
   }
 
   .minor {
-    background: rgba(242, 153, 74, 0.5);
+    background: var(--minor-outage-color);
   }
 
   .major {
-    background: rgba(235, 87, 87, 0.5);
+    background: var(--major-outage-color);
   }
 
   .operational {
-    background: rgba(39, 174, 96, 0.5);
+    background: var(--operational-color);
   }
 </style>
 

--- a/src/component/WatchlistItem.svelte
+++ b/src/component/WatchlistItem.svelte
@@ -14,19 +14,19 @@
   }
 
   .fetching {
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--fetching-color);
   }
 
   .minor {
-    background: rgba(242, 153, 74, 0.5);
+    background: var(--minor-outage-color);
   }
 
   .major {
-    background: rgba(235, 87, 87, 0.5);
+    background: var(--major-outage-color);
   }
 
   .operational {
-    background: rgba(39, 174, 96, 0.5);
+    background: var(--operational-color);
   }
 </style>
 

--- a/test/component/StatusTickerItem.test.js
+++ b/test/component/StatusTickerItem.test.js
@@ -110,7 +110,7 @@ describe('Render Status', () => {
 
     expect(status).toHaveTextContent('Fetching');
     expect(status).toHaveStyle({
-      background: 'rgba(0, 0, 0, 0.2)',
+      background: 'var(--fetching-color)',
     });
   });
 
@@ -127,7 +127,7 @@ describe('Render Status', () => {
 
     expect(status).toHaveTextContent('Minor Outage');
     expect(status).toHaveStyle({
-      background: 'rgba(242, 153, 74, 0.5)',
+      background: 'var(--minor-outage-color)',
     });
   });
 
@@ -144,7 +144,7 @@ describe('Render Status', () => {
 
     expect(status).toHaveTextContent('Major Outage');
     expect(status).toHaveStyle({
-      background: 'rgba(235, 87, 87, 0.5)',
+      background: 'var(--major-outage-color)',
     });
   });
 
@@ -160,7 +160,7 @@ describe('Render Status', () => {
 
     expect(status).toHaveTextContent('Operational');
     expect(status).toHaveStyle({
-      background: 'rgba(39, 174, 96, 0.5)',
+      background: 'var(--operational-color)',
     });
   });
 });

--- a/test/component/WatchlistItem.test.js
+++ b/test/component/WatchlistItem.test.js
@@ -42,6 +42,22 @@ describe('Render Watchlist Item', () => {
     });
   });
 
+  it('should render Fetching status w/ grey background', async () => {
+    const { getByTestId } = render(WatchlistItem, {
+      props: {
+        platform: 'Platform',
+        fetching: true,
+      },
+    });
+
+    const watchlistItem = getByTestId('watchlist-item');
+
+    expect(watchlistItem).toHaveTextContent('Platform');
+    expect(watchlistItem).toHaveStyle({
+      background: 'var(--fetching-color)',
+    });
+  });
+
   it('should render Minor Outage status w/ orange background', async () => {
     const { getByTestId } = render(WatchlistItem, {
       props: {
@@ -55,7 +71,7 @@ describe('Render Watchlist Item', () => {
 
     expect(watchlistItem).toHaveTextContent('Platform');
     expect(watchlistItem).toHaveStyle({
-      background: 'rgba(242, 153, 74, 0.5)',
+      background: 'var(--minor-outage-color)',
     });
   });
 
@@ -72,7 +88,7 @@ describe('Render Watchlist Item', () => {
 
     expect(watchlistItem).toHaveTextContent('Platform');
     expect(watchlistItem).toHaveStyle({
-      background: 'rgba(235, 87, 87, 0.5)',
+      background: 'var(--major-outage-color)',
     });
   });
 
@@ -88,7 +104,7 @@ describe('Render Watchlist Item', () => {
 
     expect(watchlistItem).toHaveTextContent('Platform');
     expect(watchlistItem).toHaveStyle({
-      background: 'rgba(39, 174, 96, 0.5)',
+      background: 'var(--operational-color)',
     });
   });
 });


### PR DESCRIPTION
## Related Issue

fix #64

## Description

Manage status colors as global variable / Make Fetching status color as `rgba(255, 255, 255, 0.2)` in dark mode

<img width="1253" alt="Screen Shot 2021-01-21 at 7 23 26 PM" src="https://user-images.githubusercontent.com/18724352/105337786-238ab800-5c1e-11eb-9f76-0cdb2d92af17.png">
